### PR TITLE
Update Data+Mime.swift

### DIFF
--- a/Source/Marcel/Data+Mime.swift
+++ b/Source/Marcel/Data+Mime.swift
@@ -332,7 +332,7 @@ extension Data {
 					lastWasSentinel = false
 					if pointingToNewline, i < (length - 1), i > 1, raw[byte: i - 2] != sentinel {					//newline. Might be a hard wrap
 						count -= 1
-						while (raw[byte: i] == newline || raw[byte: i] == cr), i < length {
+						while i < length, (raw[byte: i] == newline || raw[byte: i] == cr) {
 							i += 1
 						}
 						continue


### PR DESCRIPTION
should test if `i` is still < length before we use this index to get byte from raw.
Else it may crash... if the last character is "="